### PR TITLE
Enable media controls

### DIFF
--- a/org.gnome.Lollypop.json
+++ b/org.gnome.Lollypop.json
@@ -19,6 +19,7 @@
     "--talk-name=org.gnome.OnlineAccounts",
     "--talk-name=org.gnome.Lollypop.Portal",
     "--talk-name=ca.desrt.dconf",
+    "--own-name=org.mpris.MediaPlayer2.Lollypop",
     "--env=DCONF_USER_CONFIG_DIR=.config/dconf"
   ],
   "modules": [


### PR DESCRIPTION
Granting ownership of org.mpris.MediaPlayer2.Lollypop enables playback
control. This includes both integrations in the shell and dedicated
keyboard keys.