### PR TITLE
Stop bundling openjpeg

### DIFF
--- a/org.gnome.Lollypop.json
+++ b/org.gnome.Lollypop.json
@@ -57,21 +57,6 @@
       "build-commands": [
         "python3 setup.py install --prefix=/app --root=/"
       ],
-      "modules": [{
-        "name": "openjpeg",
-        "buildsystem": "cmake-ninja",
-        "config-opts": [
-          "-DCMAKE_BUILD_TYPE=Release"
-        ],
-        "cleanup": [
-          "/bin"
-        ],
-        "sources": [{
-          "type": "archive",
-          "url": "https://github.com/uclouvain/openjpeg/archive/v2.3.1.tar.gz",
-          "sha256": "63f5a4713ecafc86de51bfad89cc07bb788e9bba24ebbf0c4ca637621aadb6a9"
-        }]
-      }],
       "build-options": {
         "arch": {
           "i386": {


### PR DESCRIPTION
It is already in the GNOME 3.34 runtime.