### PR TITLE
Small fix: Don't remove FFmpeg-full automatically

### DIFF
--- a/org.gnome.Lollypop.json
+++ b/org.gnome.Lollypop.json
@@ -30,7 +30,7 @@
       "version": "19.08",
       "add-ld-path": ".",
       "no-autodownload": true,
-      "autodelete": true
+      "autodelete": false
     }
   },
   "cleanup-commands": [


### PR DESCRIPTION
If users install it manually, they should also be able to remove it manually. Else, it could give trouble with other applications using FFmpeg-full