### PR TITLE
Mimimum Flatpak version is now 1.8

### DIFF
--- a/org.gnome.Lollypop.json
+++ b/org.gnome.Lollypop.json
@@ -5,6 +5,7 @@
   "sdk": "org.gnome.Sdk",
   "command": "lollypop",
   "finish-args": [
+    "--require-version=1.8.0",
     "--share=ipc",
     "--share=network",
     "--socket=x11",


### PR DESCRIPTION
By enforcing a minimum version of 1.8.0, we can prevent people from running into issues related to the missing portal functionality.