### PR TITLE
Add xdg-run/gvfsd filesystem permission

### DIFF
--- a/org.gnome.Lollypop.json
+++ b/org.gnome.Lollypop.json
@@ -13,6 +13,7 @@
     "--device=dri",
     "--filesystem=xdg-music",
     "--filesystem=xdg-run/gvfs",
+    "--filesystem=xdg-run/gvfsd",
     "--talk-name=org.gtk.vfs",
     "--talk-name=org.gtk.vfs.*",
     "--talk-name=org.freedesktop.Notifications",


### PR DESCRIPTION
With GNOME 40, Lollypop currently spews a bunch of "The peer-to-peer connection failed: Error while getting peer-to-peer dbus connection: Could not connect: No such file or directory. Falling back to the session bus. Your application is probably missing --filesystem=xdg-run/gvfsd privileges." error messages when trying to index a gvfs mount. This also causes gvfsd to eventually crash with "Too many open files" as it leaks a UNIX socket every time.