### PR TITLE
Fix version for the ffmpeg-full extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You can use proprietary codecs like [.wma](https://en.wikipedia.org/wiki/Windows
 To install the extension, run the following command:
 
 ```
-flatpak install flathub org.freedesktop.Platform.ffmpeg-full//22.08
+flatpak install flathub org.freedesktop.Platform.ffmpeg-full//23.08
 ```
 
 ## Platform support

--- a/org.gnome.Lollypop.json
+++ b/org.gnome.Lollypop.json
@@ -25,7 +25,7 @@
     "add-extensions": {
         "org.freedesktop.Platform.ffmpeg-full": {
             "directory": "lib/ffmpeg",
-            "version": "22.08",
+            "version": "23.08",
             "add-ld-path": ".",
             "autodelete": false
         }


### PR DESCRIPTION
This needs to match the freedesktop-sdk version that the runtime is based and compatible with, and for GNOME 46 that has been 23.08.

Close #210