### PR TITLE
Improve cleanup commands and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,5 @@
 # Lollypop 
 
-## Codec support
-You can use proprietary codecs like [.wma](https://en.wikipedia.org/wiki/Windows_Media_Audio) and [.ra](https://en.wikipedia.org/wiki/RealAudio) by using an optional extension provided by FFmpeg.
-
-To install the extension, run the following command:
-
-```
-flatpak install flathub org.freedesktop.Platform.ffmpeg-full//24.08
-```
-
 ## Platform support
 With the release of Lollypop 1.4.8, the sandboxing of Lollypop has been improved. Sadly, this requires Flatpak 1.8.x or higher, which is not available on all platforms by default.
 

--- a/org.gnome.Lollypop.json
+++ b/org.gnome.Lollypop.json
@@ -22,75 +22,31 @@
         "--own-name=org.mpris.MediaPlayer2.Lollypop",
         "--metadata=X-DConf=migrate-path=/org/gnome/Lollypop/"
     ],
-    "add-extensions": {
-        "org.freedesktop.Platform.ffmpeg-full": {
-            "directory": "lib/ffmpeg",
-            "version": "24.08",
-            "add-ld-path": ".",
-            "autodelete": false
-        }
-    },
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/lib/python3.*/site-packages/*/test",
+        "/lib/python3.*/site-packages/*/tests",
+        "/share/bash-completion",
+        "/share/doc",
+        "/share/fish",
+        "/share/gir-1.0",
+        "/share/gtk-doc",
+        "/share/man",
+        "/share/vala",
+        "/share/zsh",
+        "*.la",
+        "*.a"
+    ],
     "cleanup-commands": [
-        "mkdir -p /app/lib/ffmpeg"
+        "python3 -m compileall --invalidation-mode=unchecked-hash /app"
     ],
     "modules": [
         "pypi-dependencies.json",
         {
-            "name": "gst-plugins-ugly",
-            "buildsystem": "meson",
-            "cleanup": [
-                "*.la",
-                "/share/gtk-doc"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-1.20.7.tar.xz",
-                    "sha256": "e761665bb3c66fb35ff3567a283b3763b494acf0fe1df8f4abeda047b22dbc55",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 15187,
-                        "stable-only": true,
-                        "versions": {
-                            "<": "1.21"
-                        },
-                        "url-template": "https://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-$version.tar.xz"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "gst-plugins-bad",
-            "buildsystem": "meson",
-            "cleanup": [
-                "*.la",
-                "/share/gtk-doc"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-1.20.7.tar.xz",
-                    "sha256": "87251beebfd1325e5118cc67774061f6e8971761ca65a9e5957919610080d195",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 21849,
-                        "stable-only": true,
-                        "versions": {
-                            "<": "1.21"
-                        },
-                        "url-template": "https://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-$version.tar.xz"
-                    }
-                }
-            ]
-        },
-        {
             "name": "gmime",
             "config-opts": [
                 "--disable-gtk-doc"
-            ],
-            "cleanup": [
-                "*.la",
-                "/share/gtk-doc"
             ],
             "sources": [
                 {
@@ -119,10 +75,6 @@
                         "url-template": "https://download.gnome.org/sources/totem-pl-parser/3.26/totem-pl-parser-$version.tar.xz"
                     }
                 }
-            ],
-            "cleanup": [
-                "/include",
-                "/share/gtk-doc"
             ]
         },
         {

--- a/pypi-dependencies.json
+++ b/pypi-dependencies.json
@@ -30,11 +30,12 @@
         {
             "name": "python3-pybind11",
             "buildsystem": "simple",
+            "cleanup": ["*"],
             "build-commands": [
                 "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pybind11\" --no-build-isolation"
             ],
             "sources": [
-				{
+                {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/ab/87/99f21e9b20899d6dc1bf7544cfe53e5fa17acc21bb267971a540425357d3/pybind11-3.0.3-py3-none-any.whl",
                     "sha256": "fb5f8e4a64946b4dcc0451c83a8c384f803bc0a62dd1ba02f199e97dbc9aad4c"
@@ -49,7 +50,7 @@
                 "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"Pillow\" --no-build-isolation"
             ],
             "sources": [
-				{
+                {
                     "type": "file",
                     "url": "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz",
                     "sha256": "a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5"


### PR DESCRIPTION
- Improve cleanup commands
- Use Gstreamer modules from runtime
- Compile pyc files to improve performance
- Update readme.md file

The installed size was reduced from 76.0 MB to 53.1 MB.

**Please don't forget to test before merging. Only tested with mp3 and m4a files.**